### PR TITLE
Adding a template sensor that has the dollar sign before the amount for accounts, and adding more information about each purchase under each "recent_transaction" sensor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,18 @@ Copy/merge /config/sensor.yaml
 
 That's it!
 
-# To-Do:
+# ~~To-Do:~~
 
-- Show full information about a purchase when clicking on a recent_transaction sensor
+- ~~Show full information about a purchase when clicking on a recent_transaction sensor~~
 
-# Cannot be added
+# ~~Cannot be added~~
 
-- Move $ to start of values, but keep total working
- - Due to Home Assistant and Jinja2's restrictions, it's not possible to add $ to the beginning of a friendly_name_template and also work out a sum for Total Balance.
+- ~~Move $ to start of values, but keep total working~~
+  - ~~Due to Home Assistant and Jinja2's restrictions, it's not possible to add $ to the beginning of a friendly_name_template and also work out a sum for Total Balance.~~
+
+Moving the dollar sign to the start of the balance can be done by adding another template sensor, which still allows for all calculations (such as total balance, and any other calculation the user wishes) to be made. Adding extra template sensors to display a "correct" value doesn't noticably slow down Home Assistant in my testing, however, YMMV
+
+
 
 # Recently Added:
 
@@ -48,3 +52,4 @@ That's it!
 - DONE - Work out IF statement to stop "Quick save transfer", "Transfer from X saving" and "Interest" from showing
   - The above one is a little messy. Ideally I'd like to create a dictionary at the top of the sensor to allow rejectattr to parse out anything included there, rather than having multiple rejectattr in the one line. baby steps though.
   -  It seems impossible to use wildcard values and my own dictionary with Jinja2's rejectattr, but I've done what I can to limit the lines from 72 onwards. Edit those to your leisure.
+- DONE - Added information about purchases when clicking on a transaction, more data fields can be added later on potentially.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ That's it!
 
 Moving the dollar sign to the start of the balance can be done by adding another template sensor, which still allows for all calculations (such as total balance, and any other calculation the user wishes) to be made. Adding extra template sensors to display a "correct" value doesn't noticably slow down Home Assistant in my testing, however, YMMV
 
+I have adjusted the sensor.yaml to reflect this change.
+
 
 
 # Recently Added:
@@ -53,3 +55,4 @@ Moving the dollar sign to the start of the balance can be done by adding another
   - The above one is a little messy. Ideally I'd like to create a dictionary at the top of the sensor to allow rejectattr to parse out anything included there, rather than having multiple rejectattr in the one line. baby steps though.
   -  It seems impossible to use wildcard values and my own dictionary with Jinja2's rejectattr, but I've done what I can to limit the lines from 72 onwards. Edit those to your leisure.
 - DONE - Added information about purchases when clicking on a transaction, more data fields can be added later on potentially.
+- DONE - Added dollar sign before account balance using an extra sensor.

--- a/sensor.yaml
+++ b/sensor.yaml
@@ -1,90 +1,228 @@
 # Up API
 
 # Retrieve Balance
-    - platform: rest
-      name: up_balances
-      resource: https://api.up.com.au/api/v1/accounts
-      headers:
-        Authorization: !secret up_api
-      method: GET
-      json_attributes:
-        - data
-      value_template: 'OK'
-    - platform: template
-      sensors:
-        # Retrieve Account Names and Balances
-        # it's ez pz to make new sensors, just copy/paste the below sensors, change the 'eg_balance' and the [x] array integers
-        spending_balance:
-          friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["displayName"] }}'
-          value_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["balance"]["value"] }}'
-          unit_of_measurement: '$'
-        rainy_day_balance:
-          friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["displayName"] }}'
-          value_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["balance"]["value"] }}'
-          unit_of_measurement: '$'
+- platform: rest
+  name: up_balances
+  resource: https://api.up.com.au/api/v1/accounts
+  headers:
+    Authorization: !secret up_api
+  method: GET
+  json_attributes:
+    - data
+  value_template: 'OK'
+- platform: template
+  sensors:
+    # Retrieve Account Names and Balances
+    # it's ez pz to make new sensors, just copy/paste the below sensors, change the 'eg_balance' and the [x] array integers
+    spending_balance:
+      friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["displayName"] }}'
+      value_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["balance"]["value"] }}'
+      unit_of_measurement: '$'
+    spending_formatted:
+      friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["displayName"] }} clean'
+      value_template: '{{ states.sensor.up_balances.attributes["data"][0]["attributes"]["balance"]["value"] }}'
+    
+    rainy_day_balance:
+      friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["displayName"] }}'
+      value_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["balance"]["value"] }}'
+      unit_of_measurement: '$'
+    rainy_day_formatted:
+      friendly_name_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["displayName"] }} clean'
+      value_template: '{{ states.sensor.up_balances.attributes["data"][1]["attributes"]["balance"]["value"] }}'
 
-  # Calculate total balance
-  # again, ez pz to add to this with further accounts
-    - platform: template
-      sensors:
-        total_balance:
-          value_template: '{{ ((states.sensor.spending_balance.state | float) + (states.sensor.rainy_day_balance.state | float))  | round(2) }}'
-          friendly_name: Total Balance
-          unit_of_measurement: '$'
+
+
+# Calculate total balance
+# again, ez pz to add to this with further accounts
+- platform: template
+  sensors:
+    total_balance:
+      value_template: '{{ ((states.sensor.spending_balance.state | float) + (states.sensor.rainy_day_balance.state | float))  | round(2) }}'
+      friendly_name: Total Balance
+      unit_of_measurement: '$'
+    total_balance_formatted:
+      friendly_name: Total Balance Clean
+      value_template: '${{ (states.sensor.total_balance.state | float ) }}'
+
 
 # Retrieve Transactions
 # This will grab the most recent 20 transactions, showing only the most recent 5, excluding any Round Up/Covers et al.
-    - platform: rest
-      name: up_transactions
-      resource: https://api.up.com.au/api/v1/transactions/?page[size]=20
-      headers:
-        Authorization: !secret up_api
-      method: GET
-      json_attributes:
-        - data
-        #- attributes
-        #- amount
-      value_template: 'OK'
-    - platform: template
-      sensors:
-        # Transaction time.
-        recent_transaction:
-          friendly_name_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[0]["attributes"]["description"] }}
-          value_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[0]["attributes"]["amount"]["value"] }}
-          unit_of_measurement: '$'
-        recent_transaction2:
-          friendly_name_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[1]["attributes"]["description"] }}
-          value_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[1]["attributes"]["amount"]["value"] }}
-          unit_of_measurement: '$'
-        recent_transaction3:
-          friendly_name_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[2]["attributes"]["description"] }}
-          value_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[2]["attributes"]["amount"]["value"] }}
-          unit_of_measurement: '$'
-        recent_transaction4:
-          friendly_name_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[3]["attributes"]["description"] }}
-          value_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[3]["attributes"]["amount"]["value"] }}
-          unit_of_measurement: '$'
-        recent_transaction5:
-          friendly_name_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[4]["attributes"]["description"] }}
-          value_template: >-
-           {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
-           {{ parsed[4]["attributes"]["amount"]["value"] }}
-          unit_of_measurement: '$'
+- platform: rest
+  name: up_transactions
+  resource: https://api.up.com.au/api/v1/transactions/?page[size]=20
+  headers:
+    Authorization: !secret up_api
+  method: GET
+  json_attributes:
+    - data
+    #- attributes
+    #- amount
+  value_template: 'OK'
+- platform: template
+  sensors:
+    # Transaction time.
+    recent_transaction:
+      friendly_name_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[0]["attributes"]["description"] }}
+      value_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[0]["attributes"]["amount"]["value"] }}
+      attribute_templates:
+        transaction_status: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {{ parsed[0]['attributes']['status'] }}
+        roundUpAmount: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[0]["attributes"]["roundUp"] == None %}
+            No Round Up Data for this Transaction
+          {% else %}
+            {{ parsed[0]['attributes']['roundUp']['amount']['value'] }}
+          {% endif %}
+        category: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[0]["relationships"]["category"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[0]["relationships"]["category"]['data']['id'] }}
+          {% endif %}
+        parentcategory: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[0]["relationships"]["parentCategory"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[0]["relationships"]["parentCategory"]['data']['id'] }}
+          {% endif %}
+      unit_of_measurement: '$'
+    recent_transaction2:
+      friendly_name_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[1]["attributes"]["description"] }}
+      value_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[1]["attributes"]["amount"]["value"] }}
+      attribute_templates:
+        transaction_status: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {{ parsed[1]['attributes']['status'] }}
+        roundUpAmount: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[1]["attributes"]["roundUp"] == None %}
+            No Round Up Data for this Transaction
+          {% else %}
+            {{ parsed[1]['attributes']['roundUp']['amount']['value'] }}
+          {% endif %}
+        category: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[1]["relationships"]["category"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[1]["relationships"]["category"]['data']['id'] }}
+          {% endif %}
+        parentcategory: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[1]["relationships"]["parentCategory"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[1]["relationships"]["parentCategory"]['data']['id'] }}
+          {% endif %}
+      unit_of_measurement: '$'
+    recent_transaction3:
+      friendly_name_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[2]["attributes"]["description"] }}
+      value_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[2]["attributes"]["amount"]["value"] }}
+      attribute_templates:
+        transaction_status: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {{ parsed[2]['attributes']['status'] }}
+        roundUpAmount: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[2]["attributes"]["roundUp"] == None %}
+            No Round Up Data for this Transaction
+          {% else %}
+            {{ parsed[2]['attributes']['roundUp']['amount']['value'] }}
+          {% endif %}
+        category: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[2]["relationships"]["category"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[2]["relationships"]["category"]['data']['id'] }}
+          {% endif %}
+        parentcategory: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[2]["relationships"]["parentCategory"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[2]["relationships"]["parentCategory"]['data']['id'] }}
+          {% endif %}
+      unit_of_measurement: '$'
+    recent_transaction4:
+      friendly_name_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[3]["attributes"]["description"] }}
+      value_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[3]["attributes"]["amount"]["value"] }}
+      attribute_templates:
+        transaction_status: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {{ parsed[3]['attributes']['status'] }}
+        roundUpAmount: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[3]["attributes"]["roundUp"] == None %}
+            No Round Up Data for this Transaction
+          {% else %}
+            {{ parsed[3]['attributes']['roundUp']['amount']['value'] }}
+          {% endif %}
+        category: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[3]["relationships"]["category"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[3]["relationships"]["category"]['data']['id'] }}
+          {% endif %}
+        parentcategory: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[3]["relationships"]["parentCategory"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[3]["relationships"]["parentCategory"]['data']['id'] }}
+          {% endif %}
+      unit_of_measurement: '$'
+    recent_transaction5:
+      friendly_name_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[4]["attributes"]["description"] }}
+      value_template: >-
+        {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+        {{ parsed[4]["attributes"]["amount"]["value"] }}
+      attribute_templates:
+        transaction_status: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {{ parsed[4]['attributes']['status'] }}
+        roundUpAmount: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[4]["attributes"]["roundUp"] == None %}
+            No Round Up Data for this Transaction
+          {% else %}
+            {{ parsed[4]['attributes']['roundUp']['amount']['value'] }}
+          {% endif %}
+        category: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[4]["relationships"]["category"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[4]["relationships"]["category"]['data']['id'] }}
+          {% endif %}
+        parentcategory: >-
+          {% set parsed = states.sensor.up_transactions.attributes["data"] | rejectattr('attributes.description', 'in',['Round Up', 'Interest', 'Cover from', 'Cover to', 'Quick save transfer from Spending', 'Quick save transfer to rainy day fund']) | list %}
+          {% if parsed[4]["relationships"]["parentCategory"]['data'] == None %}
+            No category set for this transaction
+          {% else %}
+            {{ parsed[4]["relationships"]["parentCategory"]['data']['id'] }}
+          {% endif %}
+      unit_of_measurement: '$'


### PR DESCRIPTION
This pull request completes most of the items listed in the ```readme.md``` file. 

Firstly, the major change is that there is now attribute information under each "recent_transaction" sensor, currently, I have only included **transaction_status**, **category**, **parent category**, and **round-up** amount, however, it will be fairly easy to include other fields in the future if need be. The YAML checks that these fields exist and if they don't then it sets the attribute to a static text saying that the aforementioned field doesn't exist.

Secondly, I have added another template sensor under each account balance template sensor, which takes the account value, and then appends a dollar sign ($) before it. This leaves the original sensor available for calculations by either the user or other template sensors. The added template sensor can be used to display in the front end, where the dollar sign is on the correct side of the value.

I have also fixed some indentation issues making it easier for a user to copy the code directly into their ```sensors.yaml``` without having to fix the indentation.